### PR TITLE
Fixed a problem where changing default expiration time often results in an invalid token lifetime due to double utc conversion

### DIFF
--- a/src/Token Maker/MainWindow.xaml
+++ b/src/Token Maker/MainWindow.xaml
@@ -48,7 +48,7 @@
                 <Label Grid.Row="2" Grid.Column="0" Content="Purpose of Use:" HorizontalAlignment="Right"
                        VerticalAlignment="Center" HorizontalContentAlignment="Right" Height="26" Width="Auto" />
                 <Label Grid.Row="3" Grid.Column="0" Content="Expiration:" HorizontalAlignment="Right"
-                       VerticalAlignment="Center" HorizontalContentAlignment="Right" Height="26" Width="Auto" />
+                       VerticalAlignment="Center" HorizontalContentAlignment="Right" Height="26" Width="Auto" ToolTip="enter using local date/time" />
                 <Label Grid.Row="3" Grid.Column="2" Content="Issuer:" HorizontalAlignment="Right"
                        VerticalAlignment="Center" HorizontalContentAlignment="Right" Height="26" Width="Auto" />
 

--- a/src/Token Maker/MainWindow.xaml.cs
+++ b/src/Token Maker/MainWindow.xaml.cs
@@ -50,7 +50,9 @@ namespace CommonWell.Tools
             PopulatePurposeOfUse();
             PopulateAlgorithms();
             PopulateSAMLConfirmations();
-            DateExpiration.Value = DateTime.Now.AddMinutes(5).ToUniversalTime();
+            //System.IdentityModel.Protocols.WSTrust.Lifetime converts this to a utc
+            //so user should pick it as local time
+            DateExpiration.Value = DateTime.Now.AddMinutes(5); 
             SetControlsFromSettings();
         }
 
@@ -401,7 +403,7 @@ namespace CommonWell.Tools
                 }),
                 TokenIssuerName = SetTokenIssuerName(),
                 AppliesToAddress = IUAClaimTypes.AppliesToAddress,
-                Lifetime = new Lifetime(DateTime.Now.ToUniversalTime(), DateExpiration.Value),
+                Lifetime = new Lifetime(DateTime.Now, DateExpiration.Value),
             };
             if (!String.IsNullOrEmpty(TextBoxNpi.Text))
             {
@@ -427,7 +429,7 @@ namespace CommonWell.Tools
                 }),
                 TokenIssuerName = SetTokenIssuerName(),
                 AppliesToAddress = IUAClaimTypes.AppliesToAddress,
-                Lifetime = new Lifetime(DateTime.Now.ToUniversalTime(), DateExpiration.Value),
+                Lifetime = new Lifetime(DateTime.Now, DateExpiration.Value),
             };
             if (!String.IsNullOrEmpty(TextBoxNpi.Text))
             {
@@ -450,7 +452,7 @@ namespace CommonWell.Tools
                 }),
                 TokenIssuerName = SetTokenIssuerName(),
                 AppliesToAddress = IUAClaimTypes.AppliesToAddress,
-                Lifetime = new Lifetime(DateTime.Now.ToUniversalTime(), DateExpiration.Value),
+                Lifetime = new Lifetime(DateTime.Now, DateExpiration.Value),
             };
             if (!String.IsNullOrEmpty(TextBoxNpi.Text))
             {
@@ -473,7 +475,7 @@ namespace CommonWell.Tools
                 }),
                 TokenIssuerName = SetTokenIssuerName(),
                 AppliesToAddress = CustomXpaClaimTypes.AppliesToAddress,
-                Lifetime = new Lifetime(DateTime.Now.ToUniversalTime(), DateExpiration.Value),
+                Lifetime = new Lifetime(DateTime.Now, DateExpiration.Value),
             };
             if (!String.IsNullOrEmpty(TextBoxNpi.Text))
             {

--- a/src/Token Maker/Token Maker.csproj
+++ b/src/Token Maker/Token Maker.csproj
@@ -53,7 +53,7 @@
     <ApplicationIcon>favicon.ico</ApplicationIcon>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>65C568DDEC849F50605E8B17A9C6702F429A10A2</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>3D55C279462F975A35D965D277DACA24DD0C6492</ManifestCertificateThumbprint>
   </PropertyGroup>
   <PropertyGroup>
     <ManifestKeyFile>Token Maker_TemporaryKey.pfx</ManifestKeyFile>
@@ -93,24 +93,22 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Xceed.Wpf.AvalonDock">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.2.0.0\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.4\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
     </Reference>
     <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.2.0.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.4\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
     </Reference>
     <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.2.0.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.4\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.2.0.0\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.4\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
     </Reference>
     <Reference Include="Xceed.Wpf.DataGrid">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.2.0.0\lib\net40\Xceed.Wpf.DataGrid.dll</HintPath>
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.4\lib\net40\Xceed.Wpf.DataGrid.dll</HintPath>
     </Reference>
     <Reference Include="Xceed.Wpf.Toolkit">
-      <HintPath>..\packages\Extended.Wpf.Toolkit.2.0.0\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Extended.Wpf.Toolkit.2.4\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Token Maker/packages.config
+++ b/src/Token Maker/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
-  <package id="Extended.Wpf.Toolkit" version="2.0.0" targetFramework="net45" />
+  <package id="Extended.Wpf.Toolkit" version="2.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="System.IdentityModel.Tokens.Jwt" version="1.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
System.IdentityModel.Protocols.WSTrust.Lifetime converts the dates to utc, so user should pick it as local time, and we should pass them in that way.  
